### PR TITLE
Use ptr::write_bytes instead of mem::zeroed in allocator

### DIFF
--- a/src/tree_bitmap/allocator.rs
+++ b/src/tree_bitmap/allocator.rs
@@ -190,10 +190,7 @@ impl<T: Sized> BucketVec<T> {
                 (self.spacing - index - 1) as usize,
             );
             if cfg!(debug_assertions) {
-                ptr::write(
-                    dst_ptr.offset((self.spacing - index - 1) as isize),
-                    mem::zeroed(),
-                );
+                ptr::write_bytes(dst_ptr.offset((self.spacing - index - 1) as isize), 0, 1);
             }
         }
         ret


### PR DESCRIPTION
Tests currently fail on master on latest Rust with this error:

```
failures:

---- tree_bitmap::tests::remove stdout ----
thread 'tree_bitmap::tests::remove' panicked at 'attempted to zero-initialize type `&str`, which is invalid', /home/charlie/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/mem/mod.rs:625:9

---- tree_bitmap::tests::len stdout ----
thread 'tree_bitmap::tests::len' panicked at 'attempted to zero-initialize type `&str`, which is invalid', /home/charlie/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/mem/mod.rs:625:9
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

This pull request replaces `ptr::write` and `mem::zeroed` with `ptr::write_bytes` to avoid creating a real object (or reference to such) for which zeroed bytes are invalid.